### PR TITLE
[#38] Fix warnings in binding syntax and test config, improve readability

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -19,7 +19,7 @@ config :permit, Permit.FakeApp.Repo,
   pool_size: 10
 
 # Print only warnings and errors during test
-config :logger, level: :warn
+config :logger, level: :warning
 
 ExUnit.start()
 

--- a/lib/permit/permissions/condition_parser.ex
+++ b/lib/permit/permissions/condition_parser.ex
@@ -134,11 +134,11 @@ defmodule Permit.Permissions.ConditionParser do
   end
 
   defp map_struct_selector_to_ast(
-         {{:., _, [{param, _, _}, field]}, [{:no_parens, true} | _], []} = expr,
+         {{:., _, [{param, _, _}, field]}, [{:no_parens, true} | _] = meta, []} = expr,
          selectors
        ) do
     if param in selectors do
-      {{:., [], [make_var_ast(param), field]}, [], []}
+      {{:., [], [make_var_ast(param), field]}, meta, []}
     else
       expr
     end

--- a/lib/permit/permissions/operators/gen_operator.ex
+++ b/lib/permit/permissions/operators/gen_operator.ex
@@ -45,7 +45,11 @@ defmodule Permit.Operators.GenOperator do
         not? = maybe_negate(ops)
 
         fn field_val, subject, object ->
-          not?.(apply(Kernel, symbol(), [field_val, val_fn.(subject, object)]))
+          expected_val = val_fn.(subject, object)
+          op_args = [field_val, expected_val]
+          arg = apply(Kernel, symbol(), op_args)
+
+          not?.(arg)
         end
       end
 


### PR DESCRIPTION
In addition to a trivial fix in test config, the binding syntax implementation in `Permit.Permissions.ConditionParser` has been fixed to not omit the `no_parens: true` metadata in expressions like `s.id`, which would be erroneously processed as `s.id()` which produces a warning.