### PR TITLE
[#46] [Feature]: Remove compile-time dependency on permissions module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@ All notable changes to this project will be documented in this file.
 * This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
+### Changed
+- [Breaking] Require explicitly specified `:actions_module` on `use Permit` rather than fetching it through permissions module to avoid compile-time dependency.
 
 ## [v0.3.0]
 ### Changed
 - [Breaking] Change order of args in `Permit.verify_record/3` and add delegation as `do?/3` when doing `use Permit`.
 
-  This way, permisisons to perform a dynamically computed action can be checked like this:
+  This way, permissions to perform a dynamically computed action can be checked like this:
   ```elixir
   action = :read
   can(user) |> do?(action, %Item{id: 1})

--- a/lib/permit/permissions.ex
+++ b/lib/permit/permissions.ex
@@ -11,7 +11,7 @@ defmodule Permit.Permissions do
   A very simple usage example:
   ```
   defmodule MyApp.Permissions do
-    use Permit.Permissions, actions_module: Permit.Actions.CrudActions
+    use Permit.Permissions
 
     @impl true
     def can(%MyApp.User{role: :admin}) do
@@ -30,6 +30,14 @@ defmodule Permit.Permissions do
   ```
 
   ## Named action functions
+
+  By default, Permit will generate actions functions for the 4 common CRUD actions. If you need further actions, you can define a custom actions module .and configure it in both your `Authorization` and your `Permissions` module. See `Permit.Actions` for more information.
+
+  ```elixir
+  defmodule MyApp.Permissions do
+    # actions_module defaults to Permit.Actions.CrudActions.
+    use Permit.Permissions, actions_module: MyApp.Actions
+  ```
 
   Each action defined in the `:actions_module` results in a 2-, 3-, and 4-arity function being generated.
 
@@ -97,7 +105,7 @@ defmodule Permit.Permissions do
     condition_parser = opts[:condition_parser] || (&ConditionParser.build/2)
     condition_types_module = opts[:condition_types_module] || Permit.Types.ConditionTypes
 
-    actions_module = opts |> Keyword.get(:actions_module, Permit.Actions.CrudActions)
+    actions_module = Keyword.get(opts, :actions_module, Permit.Actions.CrudActions)
 
     # Unnamed action macro
     permission_to = PermissionTo.mixin(condition_parser, condition_types_module)

--- a/test/permit/permit_test.exs
+++ b/test/permit/permit_test.exs
@@ -35,6 +35,7 @@ defmodule Permit.PermitTest do
   defmodule TestAuthorization do
     @moduledoc false
     use Permit,
+      actions_module: TestActions,
       permissions_module: Permit.PermitTest.TestPermissions
   end
 


### PR DESCRIPTION
## Description

This patch adds a mandatory `actions_module` option to `Permit.__using__/1`, removing the compile-time access to the user-supplied permissions module and thus avoiding the compile-time dependency.

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related Issues

Fixes #46 

## Testing

### Test Environment
- [x] Elixir version: 1.18.2
- [x] OTP version: 27


### Test Cases
- [x] All existing tests pass
- [ ] New tests added for new functionality at appropriate levels
- [x] Manual testing performed

## Documentation

- [ ] Updated README.md (if applicable)
- [x] Updated documentation comments (with examples for new features)
- [ ] Updated CHANGELOG.md (if applicable)

## Code Quality

- [x] Code follows the existing style conventions
- [x] Self-review of the code has been performed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] No new linting warnings introduced
- [x] No new Dialyzer warnings introduced

## Backward Compatibility

- [x] This change includes breaking changes (please describe below)
- [ ] Migration guide provided for breaking changes

### Breaking Changes

This breaks existing setups with custom action modules as the `Authorization` module will not generate the same set of predicate functions.

## Performance Impact

- [x] No performance impact

## Security Considerations

- [x] No security impact

## Checklist

- [ ] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published