### PR TITLE
fix: predicate functions should respect action grouping (#50)

### DIFF
--- a/lib/permit.ex
+++ b/lib/permit.ex
@@ -144,7 +144,7 @@ defmodule Permit do
         do: raise("Unable to create permit authorization for nil role/user")
 
       def can(who) do
-        Permit.can(who, unquote(permissions_module))
+        Permit.can(who, unquote(permissions_module), __MODULE__)
       end
 
       @impl Permit
@@ -177,11 +177,22 @@ defmodule Permit do
 
   @doc false
   def can(who, permissions_module) do
+    can(who, permissions_module, nil)
+  end
+
+  @doc false
+  def can(who, permissions_module, authorization_module) do
     who
     |> SubjectMapping.subjects()
     |> Stream.map(&permissions_module.can/1)
     |> Enum.reduce(&Permissions.concatenate(&1, &2))
-    |> then(&%Permit.Context{subject: (is_struct(who) && who) || nil, permissions: &1})
+    |> then(
+      &%Permit.Context{
+        subject: (is_struct(who) && who) || nil,
+        permissions: &1,
+        authorization_module: authorization_module
+      }
+    )
   end
 
   @doc """
@@ -204,12 +215,24 @@ defmodule Permit do
   def verify_record(
         %{
           permissions: permissions,
-          subject: subject
+          subject: subject,
+          authorization_module: authorization_module
         } = _authorization,
         action,
         resource_or_module
       ) do
-    Permissions.granted?(permissions, action, resource_or_module, subject)
+    # If authorization_module is nil (backward compatibility), fall back to direct check
+    if is_nil(authorization_module) do
+      Permissions.granted?(permissions, action, resource_or_module, subject)
+    else
+      actions_module = authorization_module.actions_module()
+
+      verify_fn = fn check_action ->
+        Permissions.granted?(permissions, check_action, resource_or_module, subject)
+      end
+
+      Permit.Actions.verify_transitively!(actions_module, action, verify_fn)
+    end
   end
 
   defp add_predicate_name(atom),

--- a/lib/permit/context.ex
+++ b/lib/permit/context.ex
@@ -4,10 +4,11 @@ defmodule Permit.Context do
   alias Permit.Types
   alias Permit.Permissions
 
-  defstruct permissions: Permissions.new(), subject: nil
+  defstruct permissions: Permissions.new(), subject: nil, authorization_module: nil
 
   @type t :: %Permit.Context{
           permissions: Permissions.t(),
-          subject: Types.subject() | nil
+          subject: Types.subject() | nil,
+          authorization_module: module() | nil
         }
 end

--- a/test/permit/actions_grouping_test.exs
+++ b/test/permit/actions_grouping_test.exs
@@ -1,0 +1,217 @@
+defmodule Permit.ActionsGroupingTest do
+  @moduledoc """
+  Tests for transitive action grouping verification.
+
+  When an action depends on other permissions (e.g., show: [:read]),
+  the authorization check should verify if the required permissions are granted.
+  """
+  use ExUnit.Case, async: true
+
+  defmodule Article do
+    defstruct [:id, :author_id, :title]
+  end
+
+  defmodule User do
+    defstruct [:id, :role]
+  end
+
+  defmodule TestActions do
+    use Permit.Actions
+
+    @impl Permit.Actions
+    def grouping_schema do
+      Map.merge(crud_grouping(), %{
+        # Phoenix-style actions that depend on CRUD permissions
+        index: [:read],
+        show: [:read],
+        edit: [:update],
+        new: [:create]
+      })
+    end
+  end
+
+  defmodule TestPermissions do
+    use Permit.Permissions, actions_module: TestActions
+
+    def can(%User{role: :admin}) do
+      permit()
+      |> all(Article)
+    end
+
+    def can(%User{id: user_id}) do
+      permit()
+      |> read(Article)
+      |> update(Article, author_id: user_id)
+    end
+
+    def can(_), do: permit()
+  end
+
+  defmodule TestAuthorization do
+    use Permit, permissions_module: TestPermissions
+  end
+
+  describe "transitive action grouping" do
+    test "show? returns true when user has :read permission and show: [:read]" do
+      user = %User{id: 1}
+      article = %Article{id: 1, author_id: 1, title: "Test"}
+
+      # User has :read permission, show action requires :read
+      assert TestAuthorization.can(user) |> TestAuthorization.show?(article)
+    end
+
+    test "index? returns true when user has :read permission and index: [:read]" do
+      user = %User{id: 1}
+
+      # User has :read permission, index action requires :read
+      assert TestAuthorization.can(user) |> TestAuthorization.index?(Article)
+    end
+
+    test "edit? returns true when user has :update permission on their own article and edit: [:update]" do
+      user = %User{id: 1}
+      article = %Article{id: 1, author_id: 1, title: "Test"}
+
+      # User has :update permission on their own articles, edit action requires :update
+      assert TestAuthorization.can(user) |> TestAuthorization.edit?(article)
+    end
+
+    test "edit? returns false when user tries to edit someone else's article" do
+      user = %User{id: 1}
+      article = %Article{id: 2, author_id: 2, title: "Test"}
+
+      # User doesn't have :update permission on other's articles
+      refute TestAuthorization.can(user) |> TestAuthorization.edit?(article)
+    end
+
+    test "new? returns false when user only has :read permission and new: [:create]" do
+      user = %User{id: 1}
+
+      # User only has :read permission, new action requires :create
+      refute TestAuthorization.can(user) |> TestAuthorization.new?(Article)
+    end
+
+    test "admin has all permissions including derived actions" do
+      admin = %User{role: :admin}
+      article = %Article{id: 1, author_id: 2, title: "Test"}
+
+      # Admin has all permissions
+      assert TestAuthorization.can(admin) |> TestAuthorization.show?(article)
+      assert TestAuthorization.can(admin) |> TestAuthorization.index?(Article)
+      assert TestAuthorization.can(admin) |> TestAuthorization.edit?(article)
+      assert TestAuthorization.can(admin) |> TestAuthorization.new?(Article)
+    end
+
+    test "direct permission check still works (read?)" do
+      user = %User{id: 1}
+      article = %Article{id: 1, author_id: 1, title: "Test"}
+
+      # Direct :read permission check
+      assert TestAuthorization.can(user) |> TestAuthorization.read?(article)
+    end
+
+    test "direct permission check for unpermitted action (delete?)" do
+      user = %User{id: 1}
+      article = %Article{id: 1, author_id: 1, title: "Test"}
+
+      # User doesn't have :delete permission
+      refute TestAuthorization.can(user) |> TestAuthorization.delete?(article)
+    end
+  end
+
+  describe "nested action grouping" do
+    defmodule NestedActions do
+      use Permit.Actions
+
+      @impl Permit.Actions
+      def grouping_schema do
+        %{
+          base: [],
+          level1: [:base],
+          level2: [:level1],
+          level3: [:level2]
+        }
+      end
+    end
+
+    defmodule NestedPermissions do
+      use Permit.Permissions, actions_module: NestedActions
+
+      def can(:user_with_base) do
+        permit()
+        |> base(Article)
+      end
+
+      def can(_), do: permit()
+    end
+
+    defmodule NestedAuthorization do
+      use Permit, permissions_module: NestedPermissions
+    end
+
+    test "nested action dependencies are resolved transitively" do
+      # User has :base permission
+      # level3 requires level2, which requires level1, which requires base
+      assert NestedAuthorization.can(:user_with_base)
+             |> NestedAuthorization.do?(:level3, Article)
+    end
+  end
+
+  describe "dependency on multiple actions" do
+    defmodule MultipleActions do
+      use Permit.Actions
+
+      @impl Permit.Actions
+      def grouping_schema do
+        %{
+          a: [],
+          b: [],
+          c: [],
+          d: [:a, :b, :c]
+        }
+      end
+    end
+
+    defmodule MultiplePermissions do
+      use Permit.Permissions, actions_module: MultipleActions
+
+      def can(:user_with_a) do
+        permit()
+        |> a(Article)
+      end
+
+      def can(:user_with_a_b_c) do
+        permit()
+        |> a(Article)
+        |> b(Article)
+        |> c(Article)
+      end
+
+      def can(:user_with_d) do
+        permit()
+        |> d(Article)
+      end
+
+      def can(_), do: permit()
+    end
+
+    defmodule MultipleAuthorization do
+      use Permit, permissions_module: MultiplePermissions
+    end
+
+    test "user with a permission cannot perform d action" do
+      refute MultipleAuthorization.can(:user_with_a) |> MultipleAuthorization.d?(Article)
+    end
+
+    test "user with a, b, and c permission can perform d action" do
+      assert MultipleAuthorization.can(:user_with_a_b_c) |> MultipleAuthorization.d?(Article)
+    end
+
+    test "user with d permission can perform d action" do
+      assert MultipleAuthorization.can(:user_with_d) |> MultipleAuthorization.d?(Article)
+    end
+
+    test "user with d permission cannot perform a action" do
+      refute MultipleAuthorization.can(:user_with_d) |> MultipleAuthorization.a?(Article)
+    end
+  end
+end

--- a/test/permit/permit_test.exs
+++ b/test/permit/permit_test.exs
@@ -16,10 +16,10 @@ defmodule Permit.PermitTest do
     @impl Permit.Actions
     def grouping_schema do
       %{
-        a: [:create],
-        b: [:read],
-        c: [:delete],
-        d: [:update]
+        a: [],
+        b: [],
+        c: [],
+        d: []
       }
     end
   end


### PR DESCRIPTION
# Pull Request

## Description

Alows authorization module to answer `true` if permission is granted for `:show` when action grouping contains `show: [:read]` and `:read` is given explicitly.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] CI/CD improvements

## Related Issues

<!-- Link any related issues -->
Fixes #50 

## Changes Made

<!-- List the main changes made in this PR -->

- Add `authorization_module` argument to `Permit.can?` function to allow traversing the action grouping map, so that with an `a: [:b, :c]` grouping and `:b:` and `:c:` granted explicilty, permission to `:a` is also resolved as true.

## Testing

<!-- Describe the tests you ran to verify your changes -->
Added test examples that ensure that with `a: [:b, :c]` grouping, `:b` and `:c` permissions coexisting make `:a` resolve to true, while `:b` alone doesn't, and permission to `:a` doesn't imply `:b` and `:c`.

### Test Environment
- [ ] Elixir version: 1.19
- [ ] OTP version: 28

### Test Cases
- [x] All existing tests pass
- [x] New tests added for new functionality at appropriate levels
- [x] Manual testing performed

## Documentation

- [ ] Updated README.md (if applicable)
- [ ] Updated documentation comments (with examples for new features)
- [ ] Updated CHANGELOG.md (if applicable)

## Code Quality

- [x] Code follows the existing style conventions
- [x] Self-review of the code has been performed
- [x] Code has been commented, particularly in hard-to-understand areas
- [x] No new linting warnings introduced
- [x] No new Dialyzer warnings introduced

## Backward Compatibility

- [ ] This change is backward compatible
- [x] This change includes breaking changes (please describe below)
- [ ] Migration guide provided for breaking changes

### Breaking Changes
If the app relied on the prior behaviour, it won't be kept compatible. That is, most commonly, in Phoenix the grouping would be given as `show: [:read]`, which means that the `:show` action requires the `:read` permission. Permit.Phoenix accounts for this, but up until now Permit itself didn't.
<!-- If there are breaking changes, describe them here -->

## Performance Impact

- [x] No performance impact
- [ ] Performance improvement
- [ ] Potential performance regression (please describe)

### Performance Notes
<!-- Describe any performance considerations -->

## Security Considerations

- [ ] No security impact
- [x] Security improvement
- [ ] Potential security impact (please describe)

## Additional Notes

<!-- Any additional information that reviewers should know -->

## Screenshots/Examples

<!-- If applicable, add screenshots or code examples -->

See added tests

## Checklist

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Reviewer Notes

<!-- Any specific areas you'd like reviewers to focus on -->

---

<!-- Thank you for contributing to Permit! -->

