### PR TITLE
Fix empty has_many associations incorrectly returning true

### DIFF
--- a/lib/permit/permissions/parsed_condition.ex
+++ b/lib/permit/permissions/parsed_condition.ex
@@ -115,7 +115,7 @@ defmodule Permit.Permissions.ParsedCondition do
         check_conditions(sub_assoc, assoc_conditions)
 
       sub_assoc when is_list(sub_assoc) ->
-        Enum.all?(sub_assoc, &check_conditions(&1, assoc_conditions))
+        Enum.any?(sub_assoc, &check_conditions(&1, assoc_conditions))
 
       sub_assoc ->
         sub_assoc == assoc_conditions

--- a/test/permit/permissions/condition_test.exs
+++ b/test/permit/permissions/condition_test.exs
@@ -78,7 +78,8 @@ defmodule Permit.Permissions.ConditionTest do
              |> ParsedCondition.satisfied?(test_object, nil)
     end
 
-    test "should not satisfy nested has-many associations" do
+    test "should use ANY semantics for has-many associations" do
+      # None of the actors have age 123, so should fail
       condition = {:actors, {:==, [age: 123]}}
 
       test_object = %Movie{actors: [%Actor{age: 666}]}
@@ -86,19 +87,45 @@ defmodule Permit.Permissions.ConditionTest do
       refute ConditionParser.build(condition)
              |> ParsedCondition.satisfied?(test_object, nil)
 
+      # With ANY semantics: at least one actor has age 666, so should PASS
       condition = {:actors, {:==, [age: 666]}}
 
       test_object = %Movie{actors: [%Actor{age: 123}, %Actor{age: 666}]}
 
-      refute ConditionParser.build(condition)
+      assert ConditionParser.build(condition)
              |> ParsedCondition.satisfied?(test_object, nil)
 
+      # At least one actor matches both age AND name conditions
       condition = {:actors, {:==, [age: 123, name: "test"]}}
 
       test_object = %Movie{
         actors: [%Actor{age: 123, name: "test"}, %Actor{age: 123, name: "test_666"}]
       }
 
+      # With ANY semantics: first actor matches both conditions
+      assert ConditionParser.build(condition)
+             |> ParsedCondition.satisfied?(test_object, nil)
+
+      # No actor matches both conditions simultaneously
+      condition = {:actors, {:==, [age: 123, name: "test"]}}
+
+      test_object = %Movie{
+        actors: [%Actor{age: 666, name: "test"}, %Actor{age: 123, name: "wrong"}]
+      }
+
+      # No single actor has both age 123 AND name "test"
+      refute ConditionParser.build(condition)
+             |> ParsedCondition.satisfied?(test_object, nil)
+    end
+
+    test "should not satisfy nested has-many associations when association is empty" do
+      condition = {:actors, {:==, [age: 123]}}
+
+      # An empty list of actors should NOT satisfy the condition
+      # because there is no actor with age 123
+      test_object = %Movie{actors: []}
+
+      # Changed to any? semantic (PR #22 in permit_ecto)
       refute ConditionParser.build(condition)
              |> ParsedCondition.satisfied?(test_object, nil)
     end


### PR DESCRIPTION
## Description

Fixes #52

This PR fixes the issue where empty has_many associations incorrectly return `true` in permission checks due to `Enum.all?([])` returning `true` (vacuous truth).

## Changes

### Core Fix
- **File**: `lib/permit/permissions/parsed_condition.ex:117`
- Changed `Enum.all?` to `Enum.any?` in `check_association/3` function
- Implements "AT LEAST ONE" (existential) semantics for has_many associations

### Test Updates
- **File**: `test/permit/permissions/condition_test.exs`
- Added test case demonstrating the empty association bug
- Updated existing test to reflect new "ANY" semantics
- Added test for when no record matches all conditions simultaneously
- Renamed test to better describe "ANY semantics" behavior

## Behavior Change

### Before (Incorrect):
```elixir
%Movie{actors: []} # Empty list
# Enum.all?([], fn -> ... end) -> true
```

### After (Correct):
```elixir
%Movie{actors: []} # Empty list
# Enum.any?([], fn -> ... end) -> false
```

## Impact

This change ensures that:
- ✓ Empty associations correctly return `false`
- ✓ At least one matching record returns `true`
- ✓ Permission rules behave consistently with Ecto query behavior

## Test Results

- ✓ All 56 tests pass in base permit library
- ✓ All 27 tests pass in permit_ecto (including the originally failing test from PR #22)

## Related

- Related to curiosum-dev/permit_ecto#22
- Discovered through inconsistency between Ecto query behavior and permission checks